### PR TITLE
fixes #70

### DIFF
--- a/include/xtensor-io/xnpz.hpp
+++ b/include/xtensor-io/xnpz.hpp
@@ -76,7 +76,7 @@ namespace xt
         };
 #pragma pack(pop)
 
-        uint64_t extract_zip64_compressed_size_within(std::istream& stream,
+        inline uint64_t extract_zip64_compressed_size_within(std::istream& stream,
                                                       std::streamsize nbytes)
         {
             for (extensible_data_field desc; nbytes > sizeof(desc);)
@@ -115,7 +115,7 @@ namespace xt
                 "load_npz: missing zip64 extended information.");
         }
 
-        uint64_t extract_zip64_compressed_size(std::istream& stream,
+        inline uint64_t extract_zip64_compressed_size(std::istream& stream,
                                                zip_local_header const& entry)
         {
             if (entry.compressed_size == 0xffffffff)


### PR DESCRIPTION
Adds two inline specifier so as to avoid multiple definition errors.