### PR TITLE
Add methods to read/write from a GDAL dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ docs/build/
 
 # Generated header
 include/xtensor-io/xtensor_io_config.hpp
+
+# CLion IDE
+.idea/
+cmake-build-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
     # Install host dependencies
     - mamba install openimageio=2.1.10 libsndfile=1.0.28 zlib=1.2.11 highfive=2.1.1 blosc xtensor=0.21.2 -c conda-forge
     - mamba install ffmpeg=4.1.3 -c conda-forge  # openimageio is missing ffmpedg as a runtime requirement
+    - mamba install gdal=3.1.2 -c conda-forge # ~127 MiB with dependencies.
     # Install build dependencies
     - mamba install cmake -c conda-forge
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ install:
     # Install mamba
     - conda install mamba -c conda-forge
     # Install host dependencies
-    - mamba install openimageio=2.1.10 libsndfile=1.0.28 zlib=1.2.11 highfive=2.1.1 blosc xtensor=0.21.2 -c conda-forge
+    - mamba install openimageio=2.1.10 libsndfile=1.0.28 zlib=1.2.11 highfive=2.1.1 blosc gdal xtensor=0.21.2 -c conda-forge
     - mamba install ffmpeg=4.1.3 -c conda-forge  # openimageio is missing ffmpedg as a runtime requirement
-    - mamba install gdal=3.1.2 -c conda-forge # ~127 MiB with dependencies.
     # Install build dependencies
     - mamba install cmake -c conda-forge
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,22 @@ else()
   message(WARNING "Blosc not found - install blosc for Blosc file support")
 endif()
 
+message(STATUS "Trying to find GDAL for geospatial raster file support")
+find_package(GDAL)
+if(${GDAL_FOUND})
+  message(STATUS "GDAL ${GDAL_VERSION} found, geospatial raster file support enabled")
+  target_include_directories(xtensor-io
+    INTERFACE
+      ${GDAL_INCLUDE_DIRS}
+  )
+  target_link_libraries(xtensor-io
+    INTERFACE
+      ${GDAL_LIBRARIES}
+  )
+else()
+  message(WARNING "GDAL not found - install GDAL for geospatial raster file support")
+endif()
+
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
 endif()

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -101,3 +101,10 @@ Defined in ``xtensor-io/xgdal.hpp``
 .. doxygenstruct:: xt::load_gdal_options
    :project: xtensor-io
    :members:
+
+.. doxygenfunction:: dump_gdal(const xexpression<T> &e, const std::string& path, dump_gdal_options options = {})
+   :project: xtensor-io
+
+.. doxygenstruct:: xt::dump_gdal_options
+   :project: xtensor-io
+   :members:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -86,3 +86,18 @@ Defined in ``xtensor-io/xhighfive.hpp``
 
 .. doxygenfunction:: xt::extensions::shape(const HighFive::File&, const std::string&)
    :project: xtensor-io
+
+GDAL files
+----------
+
+Defined in ``xtensor-io/xgdal.hpp``
+
+.. doxygenfunction:: load_gdal(const std::string &file_path, load_gdal_options options = {})
+   :project: xtensor-io
+
+.. doxygenfunction:: load_gdal(GDALDatasetH dataset, load_gdal_options options = {})
+   :project: xtensor-io
+
+.. doxygenstruct:: xt::load_gdal_options
+   :project: xtensor-io
+   :members:

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -72,3 +72,19 @@ Example : Reading and writing HDF5 files
 
         return 0;
     }
+
+Example : Reading a geospatial raster file with GDAL
+----------------------------------------------------
+
+.. code-block:: cpp
+
+    #include <xtensor/xio.hpp>
+    #include <xtensor-io/xgdal.hpp>
+
+    int main()
+    {
+        // Load every band within an example image.
+        // The returned order is band sequential (or [band, row, column]).
+        xt::xtensor<int, 3> image = xt::load_gdal<int>("/path/to/data.ext");
+        std::cout << image << std::endl;
+    }

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -73,8 +73,8 @@ Example : Reading and writing HDF5 files
         return 0;
     }
 
-Example : Reading a geospatial raster file with GDAL
-----------------------------------------------------
+Example : Reading and writing a file with GDAL
+----------------------------------------------------------------
 
 .. code-block:: cpp
 
@@ -87,4 +87,13 @@ Example : Reading a geospatial raster file with GDAL
         // The returned order is band sequential (or [band, row, column]).
         xt::xtensor<int, 3> image = xt::load_gdal<int>("/path/to/data.ext");
         std::cout << image << std::endl;
+
+        // Write the data to disk.
+        xt::dump_gdal(image, "/path/to/output.ext");
+
+        // Fancy options exist for both reading and writing.
+        // Just as an example, we'll write a GeoTiff with deflate compression.
+        xt::dump_gdal_options opt;
+        opt.creation_options.emplace_back("COMPRESS=DEFLATE");
+        xt::dump_gdal(image, "/path/to/output.ext", opt);
     }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ xtensor-io offers bindings to popular open source libraries for reading and writ
 - Images with OpenImageIO (many supported formats, among others: jpg, png, gif, tiff, bmp ...)
 - Sound files with libsndfile (supports wav, ogg files)
 - NumPy compressed file format (``npz``). Note: support for uncompressed NumPy files (``npy``) is available in core xtensor.
+- Geospatial rasters with GDAL (many supported formats_)
 
 Enabling xtensor-io in your C++ libraries
 -----------------------------------------
@@ -59,3 +60,4 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
 
 .. _`numpy to xtensor cheat sheet`: http://xtensor.readthedocs.io/en/latest/numpy.html
 .. _xtensor: https://github.com/QuantStack/xtensor
+.. _formats: https://gdal.org/drivers/raster/index.html

--- a/include/xtensor-io/xgdal.hpp
+++ b/include/xtensor-io/xgdal.hpp
@@ -311,7 +311,7 @@ namespace xt
         std::vector<int> bands_to_load;
 
         /**
-         * The error handler used to report errors (e.g. file missing or a read fails).
+         * The error handler used to report errors (like file missing or a read fails).
          * By default, a std::runtime_error is thrown when an error is encountered
          */
         std::function<void(const std::string &)> error_handler;
@@ -341,17 +341,17 @@ namespace xt
         dump_mode mode;
 
         /**
-         * The name of the GDAL driver to use (e.g. GTiff).
+         * The name of the GDAL driver to use (like GTiff).
          */
         std::string driver_name;
 
         /**
-         * Options passed to to GDAL when the dataset is created (e.g. COMPRESS=JPEG).
+         * Options passed to to GDAL when the dataset is created (like COMPRESS=JPEG).
          */
         std::vector<std::string> creation_options;
 
         /**
-         * The layout of the xarray that's dumped to disk (e.g. the given xarray is [band, row, column]).
+         * The layout of the xarray that's dumped to disk (such as [band, row, column]).
          */
         layout interleave;
 
@@ -363,7 +363,7 @@ namespace xt
         bool return_opened_dataset;
 
         /**
-         * The error handler used to report errors (e.g. failed to open dataset).
+         * The error handler used to report errors (like failed to open dataset).
          * By default, a std::runtime_error is thrown when an error is encountered.
          */
         std::function<void(const std::string &)> error_handler;

--- a/include/xtensor-io/xgdal.hpp
+++ b/include/xtensor-io/xgdal.hpp
@@ -22,312 +22,323 @@
 namespace xt
 {
 
-  enum class component {
-    band,
-    row,
-    column
-  };
-
-  using layout = std::array<component, 3>;
-
-  /**
-   * Get a band sequential layout; index order = [band, row, column].
-   */
-  inline layout layout_band_sequential()
-  {
-    return { component::band, component::row, component::column };
-  }
-  /**
-   * Get a band interleaved by yixel layout; index order = [row, column, band].
-   */
-  inline layout layout_band_interleaved_pixel()
-  {
-    return { component::row, component::column, component::band };
-  }
-  /**
-   * Get a band interleaved by line layout; index order = [row, band, column].
-   */
-  inline layout layout_band_interleaved_line()
-  {
-    return { component::row, component::band, component::column };
-  }
-
-  namespace detail
-  {
-
-    /** A type trait for converting a template type to GDALDataType value.
+    /**
+     * The GDAL IO module supports reading and writing arrays with arbitrary index order
+     * (e.g. [band,row,col]). The component enumeration contains tags for each dimension.
      */
-    template<typename T>
-    struct to_gdal_type;
-    #define XT_GDAL_DEFINE_TYPE(from, to) \
+    enum class component
+    {
+        band,
+        row,
+        column
+    };
+
+    using layout = std::array<component, 3>;
+
+    /**
+     * Get a band sequential layout; index order = [band, row, column].
+     */
+    inline layout layout_band_sequential()
+    {
+        return {component::band, component::row, component::column};
+    }
+
+    /**
+     * Get a band interleaved by yixel layout; index order = [row, column, band].
+     */
+    inline layout layout_band_interleaved_pixel()
+    {
+        return {component::row, component::column, component::band};
+    }
+
+    /**
+     * Get a band interleaved by line layout; index order = [row, band, column].
+     */
+    inline layout layout_band_interleaved_line()
+    {
+        return {component::row, component::band, component::column};
+    }
+
+    namespace detail
+    {
+
+        /** A type trait for converting a template type to GDALDataType value.
+         */
+        template<typename T>
+        struct to_gdal_type;
+#define XT_GDAL_DEFINE_TYPE(from, to) \
           template<> struct to_gdal_type<from> { \
               static const GDALDataType value = GDALDataType::to; \
           };
-    XT_GDAL_DEFINE_TYPE(int8_t, GDT_Byte)
-    XT_GDAL_DEFINE_TYPE(uint8_t, GDT_Byte)
-    XT_GDAL_DEFINE_TYPE(uint16_t, GDT_UInt16)
-    XT_GDAL_DEFINE_TYPE(int16_t, GDT_Int16)
-    XT_GDAL_DEFINE_TYPE(uint32_t, GDT_UInt32)
-    XT_GDAL_DEFINE_TYPE(int32_t, GDT_Int32)
-    XT_GDAL_DEFINE_TYPE(float, GDT_Float32)
-    XT_GDAL_DEFINE_TYPE(double, GDT_Float64)
-    #undef XT_GDAL_DEFINE_TYPE
+        XT_GDAL_DEFINE_TYPE(int8_t, GDT_Byte)
+        XT_GDAL_DEFINE_TYPE(uint8_t, GDT_Byte)
+        XT_GDAL_DEFINE_TYPE(uint16_t, GDT_UInt16)
+        XT_GDAL_DEFINE_TYPE(int16_t, GDT_Int16)
+        XT_GDAL_DEFINE_TYPE(uint32_t, GDT_UInt32)
+        XT_GDAL_DEFINE_TYPE(int32_t, GDT_Int32)
+        XT_GDAL_DEFINE_TYPE(float, GDT_Float32)
+        XT_GDAL_DEFINE_TYPE(double, GDT_Float64)
+#undef XT_GDAL_DEFINE_TYPE
 
+
+        /**
+         * A utility structure that records the spacing of pixel values (in bytes).
+         * Used to provide arguments to GDALRasterIO.
+         */
+        struct space
+        {
+            /**
+             * From GDAL documentation:
+             * The byte offset from the start of one pixel value to the start of the next pixel value within a scanline.
+             * If defaulted (0) the size of the datatype eBufType is used.
+             */
+            GSpacing pixel;
+            /**
+             * From GDAL documentation:
+             * The byte offset from the start of one scanline in pData to the start of the next.
+             * If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+             */
+            GSpacing line;
+            /**
+             * From GDAL documentation:
+             * The byte offset from the start of one bands data to the start of the next.
+             * If defaulted (0) the value will be nLineSpace * nBufYSize implying band sequential organization of the data buffer.
+             */
+            GSpacing band;
+        };
+
+
+        /**
+         * Check that the given layout is valid.
+         * @param item the layout to check.
+         * @return false in the layout has duplicate entries (e.g. {band, band, row}).
+         */
+        static bool valid_layout(layout item)
+        {
+            return
+                    item[0] != item[1] &&
+                    item[0] != item[2] &&
+                    item[1] != item[2];
+        }
+
+        /**
+         * Convert standard raster dimensions into an xt shape.
+         * @param item the layout that should be converted into a shape.
+         * @param band_count number of bands.
+         * @param nx width of the raster.
+         * @param ny height of the raster.
+         * @return an xt shape.
+         */
+        std::array<size_t, 3> layout_as_shape(layout item, size_t band_count, size_t nx, size_t ny)
+        {
+            std::map<component, size_t> dimmap
+                    {
+                            {component::band,   band_count},
+                            {component::row,    ny},
+                            {component::column, nx}
+                    };
+            return {
+                    dimmap[item[0]],
+                    dimmap[item[1]],
+                    dimmap[item[2]]
+            };
+        }
+
+        /**
+         * Take the standard raster dimensions and convert them into byte level strides for GDALRasterIO().
+         * @param item the layout to be converted into spacing.
+         * @param band_count number of bands.
+         * @param nx width of the raster.
+         * @param ny height of the raster.
+         * @param pixel_byte_count number of bytes in one pixel.
+         * @return spacing in bytes.
+         */
+        static space
+        layout_as_space(layout item, GSpacing band_count, GSpacing nx, GSpacing ny, GSpacing pixel_byte_count)
+        {
+
+            // All 6 cases are enumerated.
+            // Perhaps there's a cleaner way to write this method?
+            space ans{};
+            if (item[0] == component::band)
+            {
+                if (item[1] == component::row)
+                {
+                    // {b, y, x }
+                    ans.band = nx * ny;
+                    ans.line = nx;
+                    ans.pixel = 1;
+                }
+                else
+                {
+                    // {b, x, y}
+                    ans.band = nx * ny;
+                    ans.line = 1;
+                    ans.pixel = ny;
+                }
+            }
+            else if (item[1] == component::band)
+            {
+                if (item[0] == component::row)
+                {
+                    // {y, b, x}
+                    ans.pixel = 1;
+                    ans.line = nx * band_count;
+                    ans.band = nx;
+                }
+                else
+                {
+                    // {x, b, y}
+                    ans.pixel = ny * band_count;
+                    ans.line = 1;
+                    ans.band = ny;
+                }
+            }
+            else
+            {
+                if (item[0] == component::row)
+                {
+                    // {y, x, b}
+                    ans.pixel = band_count;
+                    ans.line = band_count * nx;
+                    ans.band = 1;
+                }
+                else
+                {
+                    // {x, y, b}
+                    ans.pixel = band_count * ny;
+                    ans.line = band_count;
+                    ans.band = 1;
+                }
+            }
+            // Convert from pixel -> bytes.
+            ans.pixel *= pixel_byte_count;
+            ans.band *= pixel_byte_count;
+            ans.line *= pixel_byte_count;
+            return ans;
+        }
+    }  // namespace detail
 
     /**
-     * A utility structure that records the spacing of pixel values (in bytes).
-     * Used to provide arguments to GDALRasterIO.
+     * Options for loading a GDAL dataset.
      */
-    struct space
+    struct load_gdal_options
     {
-      /**
-       * From GDAL documentation:
-       * The byte offset from the start of one pixel value to the start of the next pixel value within a scanline.
-       * If defaulted (0) the size of the datatype eBufType is used.
-       */
-      GSpacing pixel;
-      /**
-       * From GDAL documentation:
-       * The byte offset from the start of one scanline in pData to the start of the next.
-       * If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
-       */
-      GSpacing line;
-      /**
-       * From GDAL documentation:
-       * The byte offset from the start of one bands data to the start of the next.
-       * If defaulted (0) the value will be nLineSpace * nBufYSize implying band sequential organization of the data buffer.
-       */
-      GSpacing band;
+        /**
+         * Load every band and return band-sequential memory (index order = [band, row, column]).
+         */
+        load_gdal_options()
+                : interleave(layout_band_sequential()),
+                  bands_to_load(/*load every available band */),
+                  error_handler([](const std::string &msg)
+                                { throw std::runtime_error("load_gdal(): " + msg); })
+        {}
+
+        /**
+         * The desired layout of the returned tensor - defaults to band sequential([band, row, col]).
+         * Arbitrary index order is supported, like band interleaved by pixel ([row, col, band]).
+         */
+        layout interleave;
+
+        /**
+         * The indices of bands to read from the dataset. All bands are read if empty.
+         * @remark Per GDAL convention, these indices start at @em one (not zero).
+         */
+        std::vector<int> bands_to_load;
+
+        /**
+         * The error handler used to report errors (e.g. file missing or a read fails).
+         * By default, a std::runtime_error is thrown when an error is encountered
+         */
+        std::function<void(const std::string &)> error_handler;
     };
 
 
     /**
-     * Check that the given layout is valid.
-     * @param item the layout to check.
-     * @return false in the layout has duplicate entries (e.g. {band, band, row}).
+     * Load pixels from a GDAL dataset.
+     * @tparam T the type of pixels to return. If it doesn't match the content of the raster,
+     *           GDAL will silently cast to this data type (which may cause loss of precision).
+     * @param file_path the file to open.
+     * @param options options to use when loading.
+     * @return pixels; band sequential by default, but index order is controlled by options.
      */
-    static bool valid_layout(layout item)
+    template<typename T>
+    xtensor<T, 3> load_gdal(const std::string &file_path, load_gdal_options options = {})
     {
-      return
-          item[0] != item[1] &&
-          item[0] != item[2] &&
-          item[1] != item[2];
+        auto dataset = GDALOpen(file_path.c_str(), GDALAccess::GA_ReadOnly);
+        if (!dataset)
+        {
+            options.error_handler("error opening GDAL dataset '" + file_path + "'.");
+            return {};
+        }
+        auto ans = load_gdal < T > (dataset, std::move(options));
+        GDALClose(dataset);
+        return ans;
     }
 
     /**
-     * Convert standard raster dimensions into an xt shape.
-     * @param item the layout that should be converted into a shape.
-     * @param band_count number of bands.
-     * @param nx width of the raster.
-     * @param ny height of the raster.
-     * @return an xt shape.
+     * Load pixels from an opened GDAL dataset.
+     * @tparam T in type of pixels to return. If this doesn't match the content of the dataset,
+     *           GDAL will silently cast to this data type (which may cause loss of precision).
+     * @param dataset an opened GDAL dataset.
+     * @param options options to used when loading.
+     * @return pixels; band sequential by default, but index order is controlled by options.
      */
-    std::array<size_t, 3> layout_as_shape(layout item, size_t band_count, size_t nx, size_t ny)
+    template<typename T>
+    xtensor<T, 3> load_gdal(GDALDatasetH dataset, load_gdal_options options = {})
     {
-      std::map<component, size_t> dimmap
-          {
-              {component::band, band_count},
-              {component::row, ny},
-              {component::column, nx}
-          };
-      return {
-          dimmap[item[0]],
-          dimmap[item[1]],
-          dimmap[item[2]]
-      };
-    }
-
-    /**
-     * Take the standard raster dimensions and convert them into byte level strides for GDALRasterIO().
-     * @param item the layout to be converted into spacing.
-     * @param band_count number of bands.
-     * @param nx width of the raster.
-     * @param ny height of the raster.
-     * @param pixel_byte_count number of bytes in one pixel.
-     * @return spacing in bytes.
-     */
-    static space layout_as_space(layout item, GSpacing band_count, GSpacing nx, GSpacing ny, GSpacing pixel_byte_count) {
-
-      // All 6 cases are enumerated.
-      // Perhaps there's a cleaner way to write this method?
-      space ans{};
-      if(item[0] == component::band)
-      {
-        if(item[1] == component::row)
+        // Check if the user provided bands. If not, we'll load every band in the dataset.
+        auto &bands = options.bands_to_load;
+        if (bands.empty())
         {
-          // {b, y, x }
-          ans.band = nx * ny;
-          ans.line = nx;
-          ans.pixel = 1;
+            int count = GDALGetRasterCount(dataset);
+            bands.resize(static_cast<size_t>(count));
+            std::iota(bands.begin(), bands.end(), 1);
         }
-        else
+
+        // Pull dataset dimensions.
+        // Need both signed (for GDAL) and unsigned (for XT).
+        int band_count = static_cast<int>(bands.size());
+        int nx = GDALGetRasterXSize(dataset);
+        int ny = GDALGetRasterYSize(dataset);
+        auto band_count_u = bands.size();
+        auto nx_u = static_cast<size_t>(nx);
+        auto ny_u = static_cast<size_t>(ny);
+
+        // Setup the shape and pixel spacing based on the user provided layout.
+        if (!detail::valid_layout(options.interleave))
         {
-          // {b, x, y}
-          ans.band = nx * ny;
-          ans.line = 1;
-          ans.pixel = ny;
+            options.error_handler("the given interleave option has duplicate entries");
+            return {};
         }
-      }
-      else if(item[1] == component::band)
-      {
-        if(item[0] == component::row)
+        auto shape = detail::layout_as_shape(options.interleave, band_count_u, nx_u, ny_u);
+        auto spacing = detail::layout_as_space(options.interleave, band_count, nx, ny, sizeof(T));
+        xt::xtensor<T, 3> ans(shape);
+
+        // Read from the dataset. Again, there are some hurdles related
+        // to the arbitrary layout order.
+        auto error = GDALDatasetRasterIOEx(
+                dataset,
+                GDALRWFlag::GF_Read,
+                0, 0,
+                nx, ny,
+                ans.data(),
+                nx, ny,
+                detail::to_gdal_type<T>::value,
+                band_count,
+                bands.data(),
+                spacing.pixel,
+                spacing.line,
+                spacing.band,
+                nullptr
+        );
+        if (error != CPLErr::CE_None)
         {
-          // {y, b, x}
-          ans.pixel = 1;
-          ans.line = nx * band_count;
-          ans.band = nx;
+            options.error_handler("failed to read from dataset");
+            return {};
         }
-        else
-        {
-          // {x, b, y}
-          ans.pixel = ny * band_count;
-          ans.line = 1;
-          ans.band = ny;
-        }
-      }
-      else
-      {
-        if(item[0] == component::row)
-        {
-          // {y, x, b}
-          ans.pixel = band_count;
-          ans.line = band_count * nx;
-          ans.band = 1;
-        }
-        else
-        {
-          // {x, y, b}
-          ans.pixel = band_count * ny;
-          ans.line = band_count;
-          ans.band = 1;
-        }
-      }
-      // Convert from pixel -> bytes.
-      ans.pixel *= pixel_byte_count;
-      ans.band *= pixel_byte_count;
-      ans.line *= pixel_byte_count;
-      return ans;
+        return ans;
     }
-  }  // namespace detail
-
-  /**
-   * Options for loading a GDAL dataset.
-   */
-  struct load_gdal_options
-  {
-    /**
-     * Load every band and return band-sequential memory (index order = [band, row, column]).
-     */
-    load_gdal_options()
-      :interleave(layout_band_sequential()),
-       bands_to_load(/*load every available band */),
-       error_handler([](const std::string& msg) { throw std::runtime_error("load_gdal(): " + msg); }) {}
-
-    /**
-     * The desired layout of the returned tensor - defaults to band sequential([band, row, col]).
-     * Arbitrary index order is supported, like band interleaved by pixel ([row, col, band]).
-     */
-    layout interleave;
-
-    /**
-     * The indices of bands to read from the dataset. All bands are read if empty.
-     * @remark Per GDAL convention, these indices start at @em one (not zero).
-     */
-    std::vector<int> bands_to_load;
-
-    /**
-     * The error handler used to report errors (e.g. file missing or a read fails).
-     * By default, a std::runtime_error is thrown when an error is encountered
-     */
-    std::function<void(const std::string&)> error_handler;
-  };
-
-
-  /**
-   * Load pixels from a GDAL dataset.
-   * @tparam T the type of pixels to return. If it doesn't match the content of the raster,
-   *           GDAL will silently cast to this data type (which may cause loss of precision).
-   * @param file_path the file to open.
-   * @param options options to use when loading.
-   * @return pixels; band sequential by default, but index order is controlled by options.
-   */
-  template<typename T>
-  xtensor<T, 3> load_gdal(const std::string& file_path, load_gdal_options options = {})
-  {
-    auto dataset = GDALOpen(file_path.c_str(), GDALAccess::GA_ReadOnly);
-    if(!dataset)
-    {
-      options.error_handler("error opening GDAL dataset '" + file_path + "'.");
-      return {};
-    }
-    auto ans = load_gdal<T>(dataset, std::move(options));
-    GDALClose(dataset);
-    return ans;
-  }
-
-  /**
-   * Load pixels from an opened GDAL dataset.
-   * @tparam T in type of pixels to return. If this doesn't match the content of the dataset,
-   *           GDAL will silently cast to this data type (which may cause loss of precision).
-   * @param dataset an opened GDAL dataset.
-   * @param options options to used when loading.
-   * @return pixels; band sequential by default, but index order is controlled by options.
-   */
-  template<typename T>
-  xtensor<T, 3> load_gdal(GDALDatasetH dataset, load_gdal_options options = {})
-  {
-    // Check if the user provided bands. If not, we'll load every band in the dataset.
-    auto& bands = options.bands_to_load;
-    if(bands.empty())
-    {
-      int count = GDALGetRasterCount(dataset);
-      bands.resize(static_cast<size_t>(count));
-      std::iota(bands.begin(), bands.end(), 1);
-    }
-
-    // Pull dataset dimensions.
-    // Need both signed (for GDAL) and unsigned (for XT).
-    int band_count = static_cast<int>(bands.size());
-    int nx = GDALGetRasterXSize(dataset);
-    int ny = GDALGetRasterYSize(dataset);
-    auto band_count_u = bands.size();
-    auto nx_u = static_cast<size_t>(nx);
-    auto ny_u = static_cast<size_t>(ny);
-
-    // Setup the shape and pixel spacing based on the user provided layout.
-    if(!detail::valid_layout(options.interleave))
-    {
-      options.error_handler("the given interleave option has duplicate entries");
-      return {};
-    }
-    auto shape = detail::layout_as_shape(options.interleave, band_count_u, nx_u, ny_u);
-    auto spacing = detail::layout_as_space(options.interleave, band_count, nx, ny, sizeof(T));
-    xt::xtensor<T, 3> ans(shape);
-
-    // Read from the dataset. Again, there are some hurdles related
-    // to the arbitrary layout order.
-    auto error = GDALDatasetRasterIOEx(
-        dataset,
-        GDALRWFlag::GF_Read,
-        0, 0,
-        nx, ny,
-        ans.data(),
-        nx, ny,
-        detail::to_gdal_type<T>::value,
-        band_count,
-        bands.data(),
-        spacing.pixel,
-        spacing.line,
-        spacing.band,
-        nullptr
-      );
-    if(error != CPLErr::CE_None)
-    {
-      options.error_handler("failed to read from dataset");
-      return {};
-    }
-    return ans;
-  }
 }  // namespace xt
 
 

--- a/include/xtensor-io/xgdal.hpp
+++ b/include/xtensor-io/xgdal.hpp
@@ -1,5 +1,7 @@
 /***************************************************************************
-* TODO: need copyright guidance                                            *
+* Copyright (c) Wolf Vollprecht, Sylvain Corlay and Johan Mabille          *
+* Copyright (c) QuantStack                                                 *
+* Copyright (c) Andrew Hardin                                              *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *

--- a/include/xtensor-io/xgdal.hpp
+++ b/include/xtensor-io/xgdal.hpp
@@ -1,0 +1,332 @@
+/***************************************************************************
+* TODO: need copyright guidance                                            *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_IO_XGDAL_HPP
+#define XTENSOR_IO_XGDAL_HPP
+
+#include <functional>
+#include <map>
+
+#include <xtensor/xtensor.hpp>
+
+// We rely exclusively on the stable C interface to GDAL.
+#include <gdal.h>
+
+namespace xt
+{
+
+  enum class component {
+    band,
+    row,
+    column
+  };
+
+  using layout = std::array<component, 3>;
+
+  /**
+   * Get a band sequential layout; index order = [band, row, column].
+   */
+  inline layout layout_band_sequential()
+  {
+    return { component::band, component::row, component::column };
+  }
+  /**
+   * Get a band interleaved by yixel layout; index order = [row, column, band].
+   */
+  inline layout layout_band_interleaved_pixel()
+  {
+    return { component::row, component::column, component::band };
+  }
+  /**
+   * Get a band interleaved by line layout; index order = [row, band, column].
+   */
+  inline layout layout_band_interleaved_line()
+  {
+    return { component::row, component::band, component::column };
+  }
+
+  namespace detail
+  {
+
+    /** A type trait for converting a template type to GDALDataType value.
+     */
+    template<typename T>
+    struct to_gdal_type;
+    #define XT_GDAL_DEFINE_TYPE(from, to) \
+          template<> struct to_gdal_type<from> { \
+              static const GDALDataType value = GDALDataType::to; \
+          };
+    XT_GDAL_DEFINE_TYPE(int8_t, GDT_Byte)
+    XT_GDAL_DEFINE_TYPE(uint8_t, GDT_Byte)
+    XT_GDAL_DEFINE_TYPE(uint16_t, GDT_UInt16)
+    XT_GDAL_DEFINE_TYPE(int16_t, GDT_Int16)
+    XT_GDAL_DEFINE_TYPE(uint32_t, GDT_UInt32)
+    XT_GDAL_DEFINE_TYPE(int32_t, GDT_Int32)
+    XT_GDAL_DEFINE_TYPE(float, GDT_Float32)
+    XT_GDAL_DEFINE_TYPE(double, GDT_Float64)
+    #undef XT_GDAL_DEFINE_TYPE
+
+
+    /**
+     * A utility structure that records the spacing of pixel values (in bytes).
+     * Used to provide arguments to GDALRasterIO.
+     */
+    struct space
+    {
+      /**
+       * From GDAL documentation:
+       * The byte offset from the start of one pixel value to the start of the next pixel value within a scanline.
+       * If defaulted (0) the size of the datatype eBufType is used.
+       */
+      GSpacing pixel;
+      /**
+       * From GDAL documentation:
+       * The byte offset from the start of one scanline in pData to the start of the next.
+       * If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+       */
+      GSpacing line;
+      /**
+       * From GDAL documentation:
+       * The byte offset from the start of one bands data to the start of the next.
+       * If defaulted (0) the value will be nLineSpace * nBufYSize implying band sequential organization of the data buffer.
+       */
+      GSpacing band;
+    };
+
+
+    /**
+     * Check that the given layout is valid.
+     * @param item the layout to check.
+     * @return false in the layout has duplicate entries (e.g. {band, band, row}).
+     */
+    static bool valid_layout(layout item)
+    {
+      return
+          item[0] != item[1] &&
+          item[0] != item[2] &&
+          item[1] != item[2];
+    }
+
+    /**
+     * Convert standard raster dimensions into an xt shape.
+     * @param item the layout that should be converted into a shape.
+     * @param band_count number of bands.
+     * @param nx width of the raster.
+     * @param ny height of the raster.
+     * @return an xt shape.
+     */
+    std::array<size_t, 3> layout_as_shape(layout item, size_t band_count, size_t nx, size_t ny)
+    {
+      std::map<component, size_t> dimmap
+          {
+              {component::band, band_count},
+              {component::row, ny},
+              {component::column, nx}
+          };
+      return {
+          dimmap[item[0]],
+          dimmap[item[1]],
+          dimmap[item[2]]
+      };
+    }
+
+    /**
+     * Take the standard raster dimensions and convert them into byte level strides for GDALRasterIO().
+     * @param item the layout to be converted into spacing.
+     * @param band_count number of bands.
+     * @param nx width of the raster.
+     * @param ny height of the raster.
+     * @param pixel_byte_count number of bytes in one pixel.
+     * @return spacing in bytes.
+     */
+    static space layout_as_space(layout item, GSpacing band_count, GSpacing nx, GSpacing ny, GSpacing pixel_byte_count) {
+
+      // All 6 cases are enumerated.
+      // Perhaps there's a cleaner way to write this method?
+      space ans{};
+      if(item[0] == component::band)
+      {
+        if(item[1] == component::row)
+        {
+          // {b, y, x }
+          ans.band = nx * ny;
+          ans.line = nx;
+          ans.pixel = 1;
+        }
+        else
+        {
+          // {b, x, y}
+          ans.band = nx * ny;
+          ans.line = 1;
+          ans.pixel = ny;
+        }
+      }
+      else if(item[1] == component::band)
+      {
+        if(item[0] == component::row)
+        {
+          // {y, b, x}
+          ans.pixel = 1;
+          ans.line = nx * band_count;
+          ans.band = nx;
+        }
+        else
+        {
+          // {x, b, y}
+          ans.pixel = ny * band_count;
+          ans.line = 1;
+          ans.band = ny;
+        }
+      }
+      else
+      {
+        if(item[0] == component::row)
+        {
+          // {y, x, b}
+          ans.pixel = band_count;
+          ans.line = band_count * nx;
+          ans.band = 1;
+        }
+        else
+        {
+          // {x, y, b}
+          ans.pixel = band_count * ny;
+          ans.line = band_count;
+          ans.band = 1;
+        }
+      }
+      // Convert from pixel -> bytes.
+      ans.pixel *= pixel_byte_count;
+      ans.band *= pixel_byte_count;
+      ans.line *= pixel_byte_count;
+      return ans;
+    }
+  }  // namespace detail
+
+  /**
+   * Options for loading a GDAL dataset.
+   */
+  struct load_gdal_options
+  {
+    /**
+     * Load every band and return band-sequential memory (index order = [band, row, column]).
+     */
+    load_gdal_options()
+      :interleave(layout_band_sequential()),
+       bands_to_load(/*load every available band */),
+       error_handler([](const std::string& msg) { throw std::runtime_error("load_gdal(): " + msg); }) {}
+
+    /**
+     * The desired layout of the returned tensor - defaults to band sequential([band, row, col]).
+     * Arbitrary index order is supported, like band interleaved by pixel ([row, col, band]).
+     */
+    layout interleave;
+
+    /**
+     * The indices of bands to read from the dataset. All bands are read if empty.
+     * @remark Per GDAL convention, these indices start at @em one (not zero).
+     */
+    std::vector<int> bands_to_load;
+
+    /**
+     * The error handler used to report errors (e.g. file missing or a read fails).
+     * By default, a std::runtime_error is thrown when an error is encountered
+     */
+    std::function<void(const std::string&)> error_handler;
+  };
+
+
+  /**
+   * Load pixels from a GDAL dataset.
+   * @tparam T the type of pixels to return. If it doesn't match the content of the raster,
+   *           GDAL will silently cast to this data type (which may cause loss of precision).
+   * @param file_path the file to open.
+   * @param options options to use when loading.
+   * @return pixels; band sequential by default, but index order is controlled by options.
+   */
+  template<typename T>
+  xtensor<T, 3> load_gdal(const std::string& file_path, load_gdal_options options = {})
+  {
+    auto dataset = GDALOpen(file_path.c_str(), GDALAccess::GA_ReadOnly);
+    if(!dataset)
+    {
+      options.error_handler("error opening GDAL dataset '" + file_path + "'.");
+      return {};
+    }
+    auto ans = load_gdal<T>(dataset, std::move(options));
+    GDALClose(dataset);
+    return ans;
+  }
+
+  /**
+   * Load pixels from an opened GDAL dataset.
+   * @tparam T in type of pixels to return. If this doesn't match the content of the dataset,
+   *           GDAL will silently cast to this data type (which may cause loss of precision).
+   * @param dataset an opened GDAL dataset.
+   * @param options options to used when loading.
+   * @return pixels; band sequential by default, but index order is controlled by options.
+   */
+  template<typename T>
+  xtensor<T, 3> load_gdal(GDALDatasetH dataset, load_gdal_options options = {})
+  {
+    // Check if the user provided bands. If not, we'll load every band in the dataset.
+    auto& bands = options.bands_to_load;
+    if(bands.empty())
+    {
+      int count = GDALGetRasterCount(dataset);
+      bands.resize(static_cast<size_t>(count));
+      std::iota(bands.begin(), bands.end(), 1);
+    }
+
+    // Pull dataset dimensions.
+    // Need both signed (for GDAL) and unsigned (for XT).
+    int band_count = static_cast<int>(bands.size());
+    int nx = GDALGetRasterXSize(dataset);
+    int ny = GDALGetRasterYSize(dataset);
+    auto band_count_u = bands.size();
+    auto nx_u = static_cast<size_t>(nx);
+    auto ny_u = static_cast<size_t>(ny);
+
+    // Setup the shape and pixel spacing based on the user provided layout.
+    if(!detail::valid_layout(options.interleave))
+    {
+      options.error_handler("the given interleave option has duplicate entries");
+      return {};
+    }
+    auto shape = detail::layout_as_shape(options.interleave, band_count_u, nx_u, ny_u);
+    auto spacing = detail::layout_as_space(options.interleave, band_count, nx, ny, sizeof(T));
+    xt::xtensor<T, 3> ans(shape);
+
+    // Read from the dataset. Again, there are some hurdles related
+    // to the arbitrary layout order.
+    auto error = GDALDatasetRasterIOEx(
+        dataset,
+        GDALRWFlag::GF_Read,
+        0, 0,
+        nx, ny,
+        ans.data(),
+        nx, ny,
+        detail::to_gdal_type<T>::value,
+        band_count,
+        bands.data(),
+        spacing.pixel,
+        spacing.line,
+        spacing.band,
+        nullptr
+      );
+    if(error != CPLErr::CE_None)
+    {
+      options.error_handler("failed to read from dataset");
+      return {};
+    }
+    return ans;
+  }
+}  // namespace xt
+
+
+#endif // XTENSOR_IO_XGDAL_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,7 @@ find_package(Threads)
 
 set(XTENSOR_IO_TESTS
     main.cpp
+    test_xgdal.cpp
     test_xnpz.cpp
     test_xhighfive.cpp
     test_ximage.cpp

--- a/test/test_xgdal.cpp
+++ b/test/test_xgdal.cpp
@@ -25,15 +25,22 @@ namespace xt
             GDALRegister_GTiff();
             auto driver = GDALGetDriverByName("GTiff");
             ASSERT_NE(driver, nullptr);
-            auto ds = GDALCreate(driver, path.c_str(), nx, ny, bands, GDT_Int32, nullptr);
+            auto ds = GDALCreate(driver, in_path.c_str(), nx, ny, bands, GDT_Int32, nullptr);
             ASSERT_NE(ds, nullptr);
             auto err = GDALDatasetRasterIO(ds, GDALRWFlag::GF_Write, 0, 0, nx, ny, data.data(), nx, ny,
                                            GDALDataType::GDT_Int32, bands, nullptr, 0, 0, 0);
             ASSERT_EQ(err, CPLErr::CE_None);
             GDALClose(ds);
         }
+        void TearDown() override
+        {
+            // Delete the in-memory datasets.
+            VSIUnlink(in_path.c_str());
+            VSIUnlink(out_path.c_str());
+        }
 
-        std::string path = "/vsimem/test_file.tif";
+        std::string in_path = "/vsimem/test_file.tif";
+        std::string out_path = "/vsimem/test_file_output.tif";
         int bands = 2;
         int nx = 4;
         int ny = 3;
@@ -55,16 +62,102 @@ namespace xt
 
     };
 
-    TEST_F(xgdal_fixture, interleave)
+    TEST_F(xgdal_fixture, load_invalid_interleave)
     {
-        // Check the six interleave options.
+        load_gdal_options options;
+        options.interleave = {component::band, component::column, component::column};
+        EXPECT_THROW(load_gdal<int>(in_path, options), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, load_file_missing)
+    {
+        EXPECT_THROW(load_gdal<int>(in_path + "/file-dne.tif", {}), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, load_silent_downcast)
+    {
+        // Verify that GDAL silently downcasts the type from int to byte.
+        auto test = load_gdal<uint8_t>(in_path, {});
+        auto truth = xt::adapt(data, test.shape());
+        EXPECT_TRUE(all(equal(xt::cast<uint8_t>(truth), test)));
+    }
+
+    TEST_F(xgdal_fixture, load_invalid_band_args)
+    {
+        load_gdal_options opt;
+        opt.bands_to_load = {0}; // band out-of-range.
+        EXPECT_THROW(load_gdal<int>(in_path, opt), std::runtime_error);
+
+        opt.bands_to_load = {3}; // band out-of-range.
+        EXPECT_THROW(load_gdal<int>(in_path, opt), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, load_selected_band)
+    {
+        load_gdal_options opt;
+        opt.bands_to_load = {2};
+        auto test = load_gdal<int>(in_path, opt);
+        auto truth = xt::adapt(data.data() + nx * ny, test.shape());
+        EXPECT_TRUE(all(equal(truth, test)));
+    }
+
+    TEST_F(xgdal_fixture, load_custom_error_handler)
+    {
+        bool thrown = false;
+        load_gdal_options opt;
+        opt.error_handler = [&](const std::string &)
+        { thrown = true; };
+        auto test = load_gdal<int>(in_path + "/file-dne.tif", opt);
+        EXPECT_TRUE(thrown);
+        EXPECT_EQ(test.size(), 0);
+    }
+
+    TEST_F(xgdal_fixture, dump_invalid_interleave)
+    {
+        dump_gdal_options options;
+        options.interleave = {component::band, component::column, component::column};
+        EXPECT_THROW(dump_gdal(load_gdal<int>(in_path, {}), out_path, options), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, dump_gdal_missing_driver)
+    {
+        dump_gdal_options options;
+        options.driver_name = "missing_driver";
+        EXPECT_THROW(dump_gdal(load_gdal<int>(in_path, {}), out_path, options), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, dump_invalid_shape)
+    {
+        // Either too few or too many dimensions.
+        dump_gdal_options options;
+        xt::xtensor<int, 0> nil;
+        EXPECT_THROW(dump_gdal(nil, out_path, {}), std::runtime_error);
+        xt::xtensor<int, 4> d4;
+        EXPECT_THROW(dump_gdal(d4, out_path, {}), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, dump_invalid_path)
+    {
+        dump_gdal_options options;
+        EXPECT_THROW(dump_gdal(load_gdal<int>(in_path, {}), "/path/to/neverland", options), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, load_dump_interleave_roundtrip)
+    {
+        // Check the six interleave options passed through dump() and load().
         auto check = [&](component a, component b, component c, const std::vector<int> &vtruth)
         {
-            load_gdal_options options;
-            options.interleave = {a, b, c};
-            auto test = load_gdal<int>(path, options);
+            load_gdal_options lopt;
+            lopt.interleave = {a, b, c};
+            auto test = load_gdal<int>(in_path, lopt);
             auto truth = xt::adapt(vtruth, test.shape());
-            EXPECT_TRUE(all(equal(truth, test)));
+            EXPECT_TRUE(all(equal(truth, test))) << "load failed";
+
+            dump_gdal_options dopt;
+            dopt.interleave = lopt.interleave;
+            EXPECT_EQ(dump_gdal(truth, out_path, dopt), nullptr);
+            test = load_gdal<int>(out_path, lopt);
+            EXPECT_TRUE(all(equal(truth, test))) << "dump failed";
         };
         check(component::band, component::row, component::column,
               data);
@@ -80,53 +173,37 @@ namespace xt
               {1, 13, 5, 17, 9, 21, 2, 14, 6, 18, 10, 22, 3, 15, 7, 19, 11, 23, 4, 16, 8, 20, 12, 24});
     }
 
-    TEST_F(xgdal_fixture, invalid_interleave)
+    TEST_F(xgdal_fixture, dump_supports_2d)
     {
-        load_gdal_options options;
-        options.interleave = {component::band, component::column, component::column};
-        EXPECT_THROW(load_gdal<int>(path, options), std::runtime_error);
+        // Check that the 2D convenience hook is wired up.
+        xtensor<int, 2> simple = {
+            {1, 2, 3, 4},
+            {5, 6, 7, 8}
+        };
+        dump_gdal(simple, out_path, {});
+        auto test = load_gdal<int>(out_path, {});
+        EXPECT_TRUE(all(equal(test, simple)));
     }
 
-    TEST_F(xgdal_fixture, file_missing)
+    TEST_F(xgdal_fixture, fancy_expression)
     {
-        EXPECT_THROW(load_gdal<int>(path + "/file-dne.tif", {}), std::runtime_error);
+        // Sanity check that fancy expressions are handled.
+        xtensor<double, 2> values = {{ 2. }};
+        dump_gdal(sqrt(values), out_path, {});
+        auto test = load_gdal<double>(out_path, {});
+        EXPECT_DOUBLE_EQ(test[0], std::sqrt(2.));
     }
 
-    TEST_F(xgdal_fixture, silent_downcast)
+    TEST_F(xgdal_fixture, dump_leaves_dataset_open)
     {
-        // Verify that GDAL silently downcasts the type from int to byte.
-        auto test = load_gdal<uint8_t>(path, {});
-        auto truth = xt::adapt(data, test.shape());
-        EXPECT_TRUE(all(equal(xt::cast<uint8_t>(truth), test)));
-    }
-
-    TEST_F(xgdal_fixture, invalid_band_args)
-    {
-        load_gdal_options opt;
-        opt.bands_to_load = {0}; // band out-of-range.
-        EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
-
-        opt.bands_to_load = {3}; // band out-of-range.
-        EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
-    }
-
-    TEST_F(xgdal_fixture, selected_band)
-    {
-        load_gdal_options opt;
-        opt.bands_to_load = {2};
-        auto test = load_gdal<int>(path, opt);
-        auto truth = xt::adapt(data.data() + nx * ny, test.shape());
-        EXPECT_TRUE(all(equal(truth, test)));
-    }
-
-    TEST_F(xgdal_fixture, custom_error_handler)
-    {
-        bool thrown = false;
-        load_gdal_options opt;
-        opt.error_handler = [&](const std::string &)
-        { thrown = true; };
-        auto test = load_gdal<int>(path + "/file-dne.tif", opt);
-        EXPECT_TRUE(thrown);
-        EXPECT_EQ(test.size(), 0);
+        dump_gdal_options opt;
+        opt.return_opened_dataset = true;
+        opt.creation_options.emplace_back("COMPRESS=DEFLATE");  // also try out an create_option.
+        auto dataset = dump_gdal(load_gdal<int>(in_path, {}), out_path, opt);
+        EXPECT_NE(dataset, nullptr);
+        EXPECT_EQ(GDALGetRasterCount(dataset), bands);
+        EXPECT_EQ(GDALGetRasterXSize(dataset), nx);
+        EXPECT_EQ(GDALGetRasterYSize(dataset), ny);
+        GDALClose(dataset);
     }
 }  // namespace xt

--- a/test/test_xgdal.cpp
+++ b/test/test_xgdal.cpp
@@ -7,124 +7,126 @@
 
 namespace xt
 {
-  // Verify our type traits (maybe just a floating point and integer one).
-  static_assert(detail::to_gdal_type<float>::value == GDALDataType::GDT_Float32, "");
-  static_assert(detail::to_gdal_type<int32_t>::value == GDALDataType::GDT_Int32, "");
+    // Verify our type traits (maybe just a floating point and integer one).
+    static_assert(detail::to_gdal_type<float>::value == GDALDataType::GDT_Float32, "");
+    static_assert(detail::to_gdal_type<int32_t>::value == GDALDataType::GDT_Int32, "");
 
-  // Simple test fixture that creates an in-memory dataset with known dimensions and content.
-  class xgdal_fixture : public ::testing::Test
-  {
-  protected:
-    void SetUp() override
+    // Simple test fixture that creates an in-memory dataset with known dimensions and content.
+    class xgdal_fixture : public ::testing::Test
     {
-      // Fill the buffer of pixel data.
-      data.resize(static_cast<size_t>(bands * nx * ny));
-      std::iota(data.begin(), data.end(), 1);
+    protected:
+        void SetUp() override
+        {
+            // Fill the buffer of pixel data.
+            data.resize(static_cast<size_t>(bands * nx * ny));
+            std::iota(data.begin(), data.end(), 1);
 
-      // Create an in-memory TIFF dataset.
-      GDALRegister_GTiff();
-      auto driver = GDALGetDriverByName("GTiff");
-      ASSERT_NE(driver, nullptr);
-      auto ds = GDALCreate(driver, path.c_str(), nx, ny, bands, GDT_Int32, nullptr);
-      ASSERT_NE(ds, nullptr);
-      auto err = GDALDatasetRasterIO(ds, GDALRWFlag::GF_Write, 0, 0, nx, ny, data.data(), nx ,ny, GDALDataType::GDT_Int32, bands, nullptr, 0, 0, 0);
-      ASSERT_EQ(err, CPLErr::CE_None);
-      GDALClose(ds);
+            // Create an in-memory TIFF dataset.
+            GDALRegister_GTiff();
+            auto driver = GDALGetDriverByName("GTiff");
+            ASSERT_NE(driver, nullptr);
+            auto ds = GDALCreate(driver, path.c_str(), nx, ny, bands, GDT_Int32, nullptr);
+            ASSERT_NE(ds, nullptr);
+            auto err = GDALDatasetRasterIO(ds, GDALRWFlag::GF_Write, 0, 0, nx, ny, data.data(), nx, ny,
+                                           GDALDataType::GDT_Int32, bands, nullptr, 0, 0, 0);
+            ASSERT_EQ(err, CPLErr::CE_None);
+            GDALClose(ds);
+        }
+
+        std::string path = "/vsimem/test_file.tif";
+        int bands = 2;
+        int nx = 4;
+        int ny = 3;
+        size_t bands_u = static_cast<size_t>(bands);
+        size_t nx_u = static_cast<size_t>(nx);
+        size_t ny_u = static_cast<size_t>(ny);
+
+        /*
+         Very simple band sequential integers:
+
+          1, 2, 3, 4,       (band 1)
+          5, 6, 7, 8,
+          9, 10, 11, 12,
+          13, 14, 15, 16,   (band 2)
+          17, 18, 19, 20,
+          21, 22, 23, 24
+        */
+        std::vector<int> data;
+
+    };
+
+    TEST_F(xgdal_fixture, interleave)
+    {
+        // Check the six interleave options.
+        auto check = [&](component a, component b, component c, const std::vector<int> &vtruth)
+        {
+            load_gdal_options options;
+            options.interleave = {a, b, c};
+            auto test = load_gdal<int>(path, options);
+            auto truth = xt::adapt(vtruth, test.shape());
+            EXPECT_TRUE(all(equal(truth, test)));
+        };
+        check(component::band, component::row, component::column,
+              data);
+        check(component::band, component::column, component::row,
+              {1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12, 13, 17, 21, 14, 18, 22, 15, 19, 23, 16, 20, 24});
+        check(component::row, component::band, component::column,
+              {1, 2, 3, 4, 13, 14, 15, 16, 5, 6, 7, 8, 17, 18, 19, 20, 9, 10, 11, 12, 21, 22, 23, 24});
+        check(component::column, component::band, component::row,
+              {1, 5, 9, 13, 17, 21, 2, 6, 10, 14, 18, 22, 3, 7, 11, 15, 19, 23, 4, 8, 12, 16, 20, 24});
+        check(component::row, component::column, component::band,
+              {1, 13, 2, 14, 3, 15, 4, 16, 5, 17, 6, 18, 7, 19, 8, 20, 9, 21, 10, 22, 11, 23, 12, 24});
+        check(component::column, component::row, component::band,
+              {1, 13, 5, 17, 9, 21, 2, 14, 6, 18, 10, 22, 3, 15, 7, 19, 11, 23, 4, 16, 8, 20, 12, 24});
     }
 
-    std::string path = "/vsimem/test_file.tif";
-    int bands = 2;
-    int nx = 4;
-    int ny = 3;
-    size_t bands_u = static_cast<size_t>(bands);
-    size_t nx_u = static_cast<size_t>(nx);
-    size_t ny_u = static_cast<size_t>(ny);
-
-    /*
-     Very simple band sequential integers:
-
-      1, 2, 3, 4,       (band 1)
-      5, 6, 7, 8,
-      9, 10, 11, 12,
-      13, 14, 15, 16,   (band 2)
-      17, 18, 19, 20,
-      21, 22, 23, 24
-    */
-    std::vector<int> data;
-
-  };
-
-  TEST_F(xgdal_fixture, interleave)
-  {
-    // Check the six interleave options.
-    auto check = [&](component a, component b, component c, const std::vector<int>& vtruth)
-      {
+    TEST_F(xgdal_fixture, invalid_interleave)
+    {
         load_gdal_options options;
-        options.interleave = {a, b, c};
-        auto test = load_gdal<int>(path, options);
-        auto truth = xt::adapt(vtruth, test.shape());
+        options.interleave = {component::band, component::column, component::column};
+        EXPECT_THROW(load_gdal<int>(path, options), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, file_missing)
+    {
+        EXPECT_THROW(load_gdal<int>(path + "/file-dne.tif", {}), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, silent_downcast)
+    {
+        // Verify that GDAL silently downcasts the type from int to byte.
+        auto test = load_gdal<uint8_t>(path, {});
+        auto truth = xt::adapt(data, test.shape());
+        EXPECT_TRUE(all(equal(xt::cast<uint8_t>(truth), test)));
+    }
+
+    TEST_F(xgdal_fixture, invalid_band_args)
+    {
+        load_gdal_options opt;
+        opt.bands_to_load = {0}; // band out-of-range.
+        EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
+
+        opt.bands_to_load = {3}; // band out-of-range.
+        EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
+    }
+
+    TEST_F(xgdal_fixture, selected_band)
+    {
+        load_gdal_options opt;
+        opt.bands_to_load = {2};
+        auto test = load_gdal<int>(path, opt);
+        auto truth = xt::adapt(data.data() + nx * ny, test.shape());
         EXPECT_TRUE(all(equal(truth, test)));
-      };
-    check(component::band, component::row, component::column,
-          data);
-    check(component::band, component::column, component::row,
-          {1,5,9,2,6,10,3,7,11,4,8,12,13,17,21,14,18,22,15,19,23,16,20,24});
-    check(component::row, component::band, component::column,
-          {1,2,3,4,13,14,15,16,5,6,7,8,17,18,19,20,9,10,11,12,21,22,23,24});
-    check(component::column, component::band, component::row,
-          {1,5,9,13,17,21,2,6,10,14,18,22,3,7,11,15,19,23,4,8,12,16,20,24});
-    check(component::row, component::column, component::band,
-          {1,13,2,14,3,15,4,16,5,17,6,18,7,19,8,20,9,21,10,22,11,23,12,24});
-    check(component::column, component::row, component::band,
-          {1,13,5,17,9,21,2,14,6,18,10,22,3,15,7,19,11,23,4,16,8,20,12,24});
-  }
+    }
 
-  TEST_F(xgdal_fixture, invalid_interleave)
-  {
-    load_gdal_options options;
-    options.interleave = {component::band, component::column, component::column};
-    EXPECT_THROW(load_gdal<int>(path, options), std::runtime_error);
-  }
-
-  TEST_F(xgdal_fixture, file_missing)
-  {
-    EXPECT_THROW(load_gdal<int>(path + "/file-dne.tif", {}), std::runtime_error);
-  }
-
-  TEST_F(xgdal_fixture, silent_downcast)
-  {
-    // Verify that GDAL silently downcasts the type from int to byte.
-    auto test = load_gdal<uint8_t>(path, {});
-    auto truth = xt::adapt(data, test.shape());
-    EXPECT_TRUE(all(equal(xt::cast<uint8_t>(truth), test)));
-  }
-
-  TEST_F(xgdal_fixture, invalid_band_args)
-  {
-    load_gdal_options opt;
-    opt.bands_to_load = {0}; // band out-of-range.
-    EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
-
-    opt.bands_to_load = {3}; // band out-of-range.
-    EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
-  }
-
-  TEST_F(xgdal_fixture, selected_band)
-  {
-    load_gdal_options opt;
-    opt.bands_to_load = {2};
-    auto test = load_gdal<int>(path, opt);
-    auto truth = xt::adapt(data.data() + nx * ny, test.shape());
-    EXPECT_TRUE(all(equal(truth, test)));
-  }
-
-  TEST_F(xgdal_fixture, custom_error_handler)
-  {
-    bool thrown = false;
-    load_gdal_options opt;
-    opt.error_handler = [&](const std::string&) { thrown = true; };
-    auto test = load_gdal<int>(path + "/file-dne.tif", opt);
-    EXPECT_TRUE(thrown);
-    EXPECT_EQ(test.size(), 0);
-  }
+    TEST_F(xgdal_fixture, custom_error_handler)
+    {
+        bool thrown = false;
+        load_gdal_options opt;
+        opt.error_handler = [&](const std::string &)
+        { thrown = true; };
+        auto test = load_gdal<int>(path + "/file-dne.tif", opt);
+        EXPECT_TRUE(thrown);
+        EXPECT_EQ(test.size(), 0);
+    }
 }  // namespace xt

--- a/test/test_xgdal.cpp
+++ b/test/test_xgdal.cpp
@@ -1,0 +1,130 @@
+#include "gtest/gtest.h"
+#include "xtensor-io/xgdal.hpp"
+#include "xtensor/xadapt.hpp"
+#include "xtensor/xoperation.hpp"
+
+#include <gdal_frmts.h>
+
+namespace xt
+{
+  // Verify our type traits (maybe just a floating point and integer one).
+  static_assert(detail::to_gdal_type<float>::value == GDALDataType::GDT_Float32, "");
+  static_assert(detail::to_gdal_type<int32_t>::value == GDALDataType::GDT_Int32, "");
+
+  // Simple test fixture that creates an in-memory dataset with known dimensions and content.
+  class xgdal_fixture : public ::testing::Test
+  {
+  protected:
+    void SetUp() override
+    {
+      // Fill the buffer of pixel data.
+      data.resize(static_cast<size_t>(bands * nx * ny));
+      std::iota(data.begin(), data.end(), 1);
+
+      // Create an in-memory TIFF dataset.
+      GDALRegister_GTiff();
+      auto driver = GDALGetDriverByName("GTiff");
+      ASSERT_NE(driver, nullptr);
+      auto ds = GDALCreate(driver, path.c_str(), nx, ny, bands, GDT_Int32, nullptr);
+      ASSERT_NE(ds, nullptr);
+      auto err = GDALDatasetRasterIO(ds, GDALRWFlag::GF_Write, 0, 0, nx, ny, data.data(), nx ,ny, GDALDataType::GDT_Int32, bands, nullptr, 0, 0, 0);
+      ASSERT_EQ(err, CPLErr::CE_None);
+      GDALClose(ds);
+    }
+
+    std::string path = "/vsimem/test_file.tif";
+    int bands = 2;
+    int nx = 4;
+    int ny = 3;
+    size_t bands_u = static_cast<size_t>(bands);
+    size_t nx_u = static_cast<size_t>(nx);
+    size_t ny_u = static_cast<size_t>(ny);
+
+    /*
+     Very simple band sequential integers:
+
+      1, 2, 3, 4,       (band 1)
+      5, 6, 7, 8,
+      9, 10, 11, 12,
+      13, 14, 15, 16,   (band 2)
+      17, 18, 19, 20,
+      21, 22, 23, 24
+    */
+    std::vector<int> data;
+
+  };
+
+  TEST_F(xgdal_fixture, interleave)
+  {
+    // Check the six interleave options.
+    auto check = [&](component a, component b, component c, const std::vector<int>& vtruth)
+      {
+        load_gdal_options options;
+        options.interleave = {a, b, c};
+        auto test = load_gdal<int>(path, options);
+        auto truth = xt::adapt(vtruth, test.shape());
+        EXPECT_TRUE(all(equal(truth, test)));
+      };
+    check(component::band, component::row, component::column,
+          data);
+    check(component::band, component::column, component::row,
+          {1,5,9,2,6,10,3,7,11,4,8,12,13,17,21,14,18,22,15,19,23,16,20,24});
+    check(component::row, component::band, component::column,
+          {1,2,3,4,13,14,15,16,5,6,7,8,17,18,19,20,9,10,11,12,21,22,23,24});
+    check(component::column, component::band, component::row,
+          {1,5,9,13,17,21,2,6,10,14,18,22,3,7,11,15,19,23,4,8,12,16,20,24});
+    check(component::row, component::column, component::band,
+          {1,13,2,14,3,15,4,16,5,17,6,18,7,19,8,20,9,21,10,22,11,23,12,24});
+    check(component::column, component::row, component::band,
+          {1,13,5,17,9,21,2,14,6,18,10,22,3,15,7,19,11,23,4,16,8,20,12,24});
+  }
+
+  TEST_F(xgdal_fixture, invalid_interleave)
+  {
+    load_gdal_options options;
+    options.interleave = {component::band, component::column, component::column};
+    EXPECT_THROW(load_gdal<int>(path, options), std::runtime_error);
+  }
+
+  TEST_F(xgdal_fixture, file_missing)
+  {
+    EXPECT_THROW(load_gdal<int>(path + "/file-dne.tif", {}), std::runtime_error);
+  }
+
+  TEST_F(xgdal_fixture, silent_downcast)
+  {
+    // Verify that GDAL silently downcasts the type from int to byte.
+    auto test = load_gdal<uint8_t>(path, {});
+    auto truth = xt::adapt(data, test.shape());
+    EXPECT_TRUE(all(equal(xt::cast<uint8_t>(truth), test)));
+  }
+
+  TEST_F(xgdal_fixture, invalid_band_args)
+  {
+    load_gdal_options opt;
+    opt.bands_to_load = {0}; // band out-of-range.
+    EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
+
+    opt.bands_to_load = {3}; // band out-of-range.
+    EXPECT_THROW(load_gdal<int>(path, opt), std::runtime_error);
+  }
+
+  TEST_F(xgdal_fixture, selected_band)
+  {
+    load_gdal_options opt;
+    opt.bands_to_load = {2};
+    auto test = load_gdal<int>(path, opt);
+    auto truth = xt::adapt(data.data() + nx * ny, test.shape());
+    EXPECT_TRUE(all(equal(truth, test)));
+  }
+
+  TEST_F(xgdal_fixture, custom_error_handler)
+  {
+    bool thrown = false;
+    load_gdal_options opt;
+    opt.error_handler = [&](const std::string&) { thrown = true; };
+    auto test = load_gdal<int>(path + "/file-dne.tif", opt);
+    EXPECT_TRUE(thrown);
+    EXPECT_EQ(test.size(), 0);
+  }
+}  // namespace xt


### PR DESCRIPTION
This PR adds the ability to read/write from a GDAL dataset. It's tagged as WIP because only the read functionality has been implemented.

I have two questions for the project maintainers:

1. Most files have a standard copyright block at the top. What's the recommended boilerplate for contributed files? Just copy + paste what's already being used?

2. I see that Travis CI is being used. Should GDAL be added to the set of dependencies for CI (e.g. `mamba install gdal=[ver]`)?