### PR TITLE
Reshape after reading

### DIFF
--- a/include/xtensor-io/xblosc.hpp
+++ b/include/xtensor-io/xblosc.hpp
@@ -174,7 +174,17 @@ namespace xt
     template <class E>
     void load_file(std::istream& stream, xexpression<E>& e, const xblosc_config&)
     {
-        e.derived_cast() = load_blosc<typename E::value_type>(stream);
+        E& ex = e.derived_cast();
+        auto shape = ex.shape();
+        ex = load_blosc<typename E::value_type>(stream);
+        if (!shape.empty())
+        {
+            if (compute_size(shape) != ex.size())
+            {
+                XTENSOR_THROW(std::runtime_error, "load_file: size mismatch");
+            }
+            ex.reshape(shape);
+        }
     }
 
     template <class E>

--- a/include/xtensor-io/xgzip.hpp
+++ b/include/xtensor-io/xgzip.hpp
@@ -200,7 +200,17 @@ namespace xt
     template <class E>
     void load_file(std::istream& stream, xexpression<E>& e, const xgzip_config&)
     {
-        e.derived_cast() = load_gzip<typename E::value_type>(stream);
+        E& ex = e.derived_cast();
+        auto shape = ex.shape();
+        ex = load_gzip<typename E::value_type>(stream);
+        if (!shape.empty())
+        {
+            if (compute_size(shape) != ex.size())
+            {
+                XTENSOR_THROW(std::runtime_error, "load_file: size mismatch");
+            }
+            ex.reshape(shape);
+        }
     }
 
     template <class E>

--- a/include/xtensor-io/xio_binary.hpp
+++ b/include/xtensor-io/xio_binary.hpp
@@ -130,7 +130,17 @@ namespace xt
     template <class E>
     void load_file(std::istream& stream, xexpression<E>& e, const xio_binary_config&)
     {
-        e.derived_cast() = load_bin<typename E::value_type>(stream);
+        E& ex = e.derived_cast();
+        auto shape = ex.shape();
+        ex = load_bin<typename E::value_type>(stream);
+        if (!shape.empty())
+        {
+            if (compute_size(shape) != ex.size())
+            {
+                XTENSOR_THROW(std::runtime_error, "load_file: size mismatch");
+            }
+            ex.reshape(shape);
+        }
     }
 
     template <class E>

--- a/test/test_xblosc.cpp
+++ b/test/test_xblosc.cpp
@@ -29,7 +29,6 @@ namespace xt
         //     f.write(c)
         using dtype = double;
         auto a0 = load_blosc<dtype>("files/test.blosc");
-        std::cout << a0.shape()[0] << std::endl;
         xarray<dtype> a1 = {3, 2, 1, 0};
         EXPECT_TRUE(xt::all(xt::equal(a0, a1)));
     }


### PR DESCRIPTION
Blosc, gzip and binary file formats don't store the shape, so we need to reshape after reading.