### PR TITLE
Add write method

### DIFF
--- a/include/xtensor-io/xblosc.hpp
+++ b/include/xtensor-io/xblosc.hpp
@@ -175,7 +175,7 @@ namespace xt
         }
 
         template <class T>
-        void write(T& j) const
+        void write_to(T& j) const
         {
             j["clevel"] = clevel;
             j["shuffle"] = doshuffle;

--- a/include/xtensor-io/xblosc.hpp
+++ b/include/xtensor-io/xblosc.hpp
@@ -22,12 +22,12 @@ namespace xt
     namespace detail
     {
         template <typename T>
-        inline std::vector<T> load_blosc_file(std::istream& stream)
+        inline xt::svector<T> load_blosc_file(std::istream& stream)
         {
             stream.seekg(0, stream.end);
             auto compressed_size = static_cast<std::size_t>(stream.tellg());
             stream.seekg(0, stream.beg);
-            std::vector<char> compressed_buffer(compressed_size);
+            xt::svector<char> compressed_buffer(compressed_size);
             stream.read(compressed_buffer.data(), (std::streamsize)compressed_size);
             std::size_t uncompressed_size = 0;
             int res = blosc_cbuffer_validate(compressed_buffer.data(), compressed_size, &uncompressed_size);
@@ -38,7 +38,7 @@ namespace xt
             size_t ubuf_size = uncompressed_size / sizeof(T);
             if (uncompressed_size % sizeof(T) != size_t(0))
                 ubuf_size += size_t(1);
-            std::vector<T> uncompressed_buffer(ubuf_size);
+            xt::svector<T> uncompressed_buffer(ubuf_size);
             res = blosc_decompress(compressed_buffer.data(), uncompressed_buffer.data(), uncompressed_size);
             if (res <= 0)
             {
@@ -133,7 +133,7 @@ namespace xt
     template <typename T, layout_type L = layout_type::dynamic>
     inline auto load_blosc(std::istream& stream)
     {
-        std::vector<T> uncompressed_buffer = detail::load_blosc_file<T>(stream);
+        xt::svector<T> uncompressed_buffer = detail::load_blosc_file<T>(stream);
         std::vector<std::size_t> shape = {uncompressed_buffer.size()};
         auto array = adapt(std::move(uncompressed_buffer), shape);
         return array;

--- a/include/xtensor-io/xblosc.hpp
+++ b/include/xtensor-io/xblosc.hpp
@@ -173,6 +173,13 @@ namespace xt
             , doshuffle(1)
         {
         }
+
+        template <class T>
+        void write(T& j) const
+        {
+            j["clevel"] = clevel;
+            j["shuffle"] = doshuffle;
+        }
     };
 
     template <class E>

--- a/include/xtensor-io/xgzip.hpp
+++ b/include/xtensor-io/xgzip.hpp
@@ -199,6 +199,12 @@ namespace xt
             , level(1)
         {
         }
+
+        template <class T>
+        void write(T& j) const
+        {
+            j["level"] = level;
+        }
     };
 
     template <class E>

--- a/include/xtensor-io/xgzip.hpp
+++ b/include/xtensor-io/xgzip.hpp
@@ -207,7 +207,7 @@ namespace xt
         }
 
         template <class T>
-        void write(T& j) const
+        void write_to(T& j) const
         {
             j["level"] = level;
         }

--- a/include/xtensor-io/xgzip.hpp
+++ b/include/xtensor-io/xgzip.hpp
@@ -26,9 +26,9 @@ namespace xt
     namespace detail
     {
         template <typename T>
-        inline std::vector<T> load_gzip_file(std::istream& stream)
+        inline xt::svector<T> load_gzip_file(std::istream& stream)
         {
-            std::vector<T> uncompressed_buffer;
+            xt::svector<T> uncompressed_buffer;
             z_stream zs = {0};
             unsigned char in[GZIP_CHUNK];
             T out[GZIP_CHUNK / sizeof(T)];
@@ -63,7 +63,13 @@ namespace xt
                             return uncompressed_buffer;
                     }
                     have = GZIP_CHUNK - zs.avail_out;
-                    uncompressed_buffer.insert(std::end(uncompressed_buffer), out, out + have / sizeof(T));
+                    // not possible to insert in a xt::svector currently
+                    //uncompressed_buffer.insert(std::end(uncompressed_buffer), out, out + have / sizeof(T));
+                    // so just loop for now
+                    for (int i = 0; i < have / sizeof(T); i++)
+                    {
+                        uncompressed_buffer.push_back(out[i]);
+                    }
                 }
                 while (zs.avail_out == 0);
                 if (stream.eof())
@@ -161,7 +167,7 @@ namespace xt
     template <typename T, layout_type L = layout_type::dynamic>
     inline auto load_gzip(std::istream& stream)
     {
-        std::vector<T> uncompressed_buffer = detail::load_gzip_file<T>(stream);
+        xt::svector<T> uncompressed_buffer = detail::load_gzip_file<T>(stream);
         std::vector<std::size_t> shape = {uncompressed_buffer.size()};
         auto array = adapt(std::move(uncompressed_buffer), shape);
         return array;

--- a/include/xtensor-io/xio_binary.hpp
+++ b/include/xtensor-io/xio_binary.hpp
@@ -133,6 +133,11 @@ namespace xt
             , version("1.0")
         {
         }
+
+        template <class T>
+        void write(T& j) const
+        {
+        }
     };
 
     template <class E>

--- a/include/xtensor-io/xio_binary.hpp
+++ b/include/xtensor-io/xio_binary.hpp
@@ -19,12 +19,12 @@ namespace xt
     namespace detail
     {
         template <typename T>
-        inline std::vector<T> load_bin_file(std::istream& stream)
+        inline xt::svector<T> load_bin_file(std::istream& stream)
         {
             stream.seekg(0, stream.end);
             auto uncompressed_size = static_cast<std::size_t>(stream.tellg());
             stream.seekg(0, stream.beg);
-            std::vector<T> uncompressed_buffer(uncompressed_size / sizeof(T));
+            xt::svector<T> uncompressed_buffer(uncompressed_size / sizeof(T));
             stream.read(reinterpret_cast<char*>(uncompressed_buffer.data()), (std::streamsize)uncompressed_size);
             return uncompressed_buffer;
         }
@@ -97,7 +97,7 @@ namespace xt
     template <typename T, layout_type L = layout_type::dynamic>
     inline auto load_bin(std::istream& stream)
     {
-        std::vector<T> uncompressed_buffer = detail::load_bin_file<T>(stream);
+        xt::svector<T> uncompressed_buffer = detail::load_bin_file<T>(stream);
         std::vector<std::size_t> shape = {uncompressed_buffer.size()};
         auto array = adapt(std::move(uncompressed_buffer), shape);
         return array;

--- a/include/xtensor-io/xio_binary.hpp
+++ b/include/xtensor-io/xio_binary.hpp
@@ -135,7 +135,7 @@ namespace xt
         }
 
         template <class T>
-        void write(T& j) const
+        void write_to(T& j) const
         {
         }
     };


### PR DESCRIPTION
This is needed in xtensor-zarr, and allows to write the configuration parameters to a JSON-like object (typically `nlohmann::json`).