### PR TITLE
Allow pool_size=0

### DIFF
--- a/include/xtensor-io/xchunk_store_manager.hpp
+++ b/include/xtensor-io/xchunk_store_manager.hpp
@@ -218,7 +218,7 @@ namespace xt
         : m_shape(shape)
         , m_unload_index(0u)
     {
-        if (pool_size == -1)
+        if (pool_size == 0)
         {
             // as many "physical" chunks in the pool as there are "logical" chunks
             pool_size = size();


### PR DESCRIPTION
Sorry for the previous commit, since `pool_size` is of type `size_t` it cannot be negative. Let's choose `0` as the value to automatically size the chunk pool to the total number of chunks, since it's not an allowed value otherwise.