### PR TITLE
Support initialized list for chunked_file_array shapes

### DIFF
--- a/include/xtensor-io/xchunk_store_manager.hpp
+++ b/include/xtensor-io/xchunk_store_manager.hpp
@@ -387,13 +387,9 @@ namespace xt
     chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path, std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using sh_type = std::vector<std::size_t>;
-        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
-        std::copy(shape.begin(), shape.end(), sh.begin());
-        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
-        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
-        using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
-        chunk_storage chunks(sh, ch_sh, path, pool_size, chunk_memory_layout);
-        return xchunked_array<chunk_storage, EXT>(std::move(chunks), std::move(sh), std::move(ch_sh));
+        auto sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(shape);
+        auto ch_sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(chunk_shape);
+        return chunked_file_array<T, IOH, L, IP, EXT, sh_type>(std::move(sh), std::move(ch_sh), path, pool_size, chunk_memory_layout);
     }
 
     template <class T, class IOH, layout_type L, class IP, class EXT, class S>
@@ -410,13 +406,9 @@ namespace xt
     chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path,  const T& init_value, std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using sh_type = std::vector<std::size_t>;
-        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
-        std::copy(shape.begin(), shape.end(), sh.begin());
-        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
-        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
-        using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
-        chunk_storage chunks(sh, ch_sh, path, pool_size, init_value, chunk_memory_layout);
-        return xchunked_array<chunk_storage, EXT>(std::move(chunks), std::move(sh), std::move(ch_sh));
+        auto sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(shape);
+        auto ch_sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(chunk_shape);
+        return chunked_file_array<T, IOH, L, IP, EXT, sh_type>(std::move(sh), std::move(ch_sh), path, init_value, pool_size, chunk_memory_layout);
     }
 
     template <class IOH, layout_type L, class IP, class EXT, class E, class S>

--- a/include/xtensor-io/xchunk_store_manager.hpp
+++ b/include/xtensor-io/xchunk_store_manager.hpp
@@ -226,6 +226,14 @@ namespace xt
                        std::size_t pool_size = 1,
                        layout_type chunk_memory_layout = XTENSOR_DEFAULT_LAYOUT);
 
+    template <class T, class IOH, layout_type L = XTENSOR_DEFAULT_LAYOUT, class IP = xindex_path, class EXT = empty_extension, class S>
+    xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
+    chunked_file_array(std::initializer_list<S> shape,
+                       std::initializer_list<S> chunk_shape,
+                       const std::string& path,
+                       std::size_t pool_size = 1,
+                       layout_type chunk_memory_layout = XTENSOR_DEFAULT_LAYOUT);
+
     /**
      * Creates a chunked file array.
      * This function returns an uninitialized ``xchunked_array<xchunk_store_manager<xfile_array<T, IOH>>>``.
@@ -249,6 +257,15 @@ namespace xt
     xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
     chunked_file_array(S&& shape,
                        S&& chunk_shape,
+                       const std::string& path,
+                       const T& init_value,
+                       std::size_t pool_size = 1,
+                       layout_type chunk_memory_layout = XTENSOR_DEFAULT_LAYOUT);
+
+    template <class T, class IOH, layout_type L = XTENSOR_DEFAULT_LAYOUT, class IP = xindex_path, class EXT = empty_extension, class S>
+    xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
+    chunked_file_array(std::initializer_list<S> shape,
+                       std::initializer_list<S> chunk_shape,
                        const std::string& path,
                        const T& init_value,
                        std::size_t pool_size = 1,
@@ -367,11 +384,39 @@ namespace xt
 
     template <class T, class IOH, layout_type L, class IP, class EXT, class S>
     inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
+    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path, std::size_t pool_size, layout_type chunk_memory_layout)
+    {
+        using sh_type = std::vector<std::size_t>;
+        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
+        std::copy(shape.begin(), shape.end(), sh.begin());
+        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
+        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
+        using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
+        chunk_storage chunks(sh, ch_sh, path, pool_size, chunk_memory_layout);
+        return xchunked_array<chunk_storage, EXT>(std::move(chunks), std::move(sh), std::move(ch_sh));
+    }
+
+    template <class T, class IOH, layout_type L, class IP, class EXT, class S>
+    inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
     chunked_file_array(S&& shape, S&& chunk_shape, const std::string& path,  const T& init_value,std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
         chunk_storage chunks(shape, chunk_shape, path, pool_size, init_value, chunk_memory_layout);
         return xchunked_array<chunk_storage, EXT>(std::move(chunks), std::forward<S>(shape), std::forward<S>(chunk_shape));
+    }
+
+    template <class T, class IOH, layout_type L, class IP, class EXT, class S>
+    inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
+    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path,  const T& init_value,std::size_t pool_size, layout_type chunk_memory_layout)
+    {
+        using sh_type = std::vector<std::size_t>;
+        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
+        std::copy(shape.begin(), shape.end(), sh.begin());
+        sh_type ch_sh = xtl::make_sequence<sh_type>(chunk_shape.size());
+        std::copy(chunk_shape.begin(), chunk_shape.end(), ch_sh.begin());
+        using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
+        chunk_storage chunks(sh, ch_sh, path, pool_size, init_value, chunk_memory_layout);
+        return xchunked_array<chunk_storage, EXT>(std::move(chunks), std::move(sh), std::move(ch_sh));
     }
 
     template <class IOH, layout_type L, class IP, class EXT, class E, class S>

--- a/include/xtensor-io/xchunk_store_manager.hpp
+++ b/include/xtensor-io/xchunk_store_manager.hpp
@@ -398,7 +398,7 @@ namespace xt
 
     template <class T, class IOH, layout_type L, class IP, class EXT, class S>
     inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
-    chunked_file_array(S&& shape, S&& chunk_shape, const std::string& path,  const T& init_value,std::size_t pool_size, layout_type chunk_memory_layout)
+    chunked_file_array(S&& shape, S&& chunk_shape, const std::string& path, const T& init_value, std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using chunk_storage = xchunk_store_manager<xfile_array<T, IOH, L>, IP>;
         chunk_storage chunks(shape, chunk_shape, path, pool_size, init_value, chunk_memory_layout);
@@ -407,7 +407,7 @@ namespace xt
 
     template <class T, class IOH, layout_type L, class IP, class EXT, class S>
     inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>, EXT>
-    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path,  const T& init_value,std::size_t pool_size, layout_type chunk_memory_layout)
+    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path,  const T& init_value, std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using sh_type = std::vector<std::size_t>;
         sh_type sh = xtl::make_sequence<sh_type>(shape.size());

--- a/include/xtensor-io/xfile_array.hpp
+++ b/include/xtensor-io/xfile_array.hpp
@@ -675,6 +675,7 @@ namespace xt
                     if (m_init)
                     {
                         std::fill(m_storage.begin(), m_storage.end(), m_init_value);
+                        m_dirty = true;
                     }
                 }
             }

--- a/test/test_xchunk_store_manager.cpp
+++ b/test/test_xchunk_store_manager.cpp
@@ -121,4 +121,15 @@ namespace xt
             EXPECT_EQ(v, init_value);
         }
     }
+
+    TEST(xchunked_array, shape_initializer_list)
+    {
+        std::vector<size_t> shape = {4, 4};
+        std::vector<size_t> chunk_shape = {2, 2};
+        auto a = chunked_file_array<double, xio_disk_handler<xio_binary_config>>({4, 4}, {2, 2}, "files3");
+        for (auto v: a)
+        {
+            EXPECT_EQ(v, 5.5);
+        }
+    }
 }


### PR DESCRIPTION
This allows to write:
```cpp
auto a = chunked_file_array<int>({4, 4}, {2, 2}, "path");
```