### PR TITLE
Don't flag xfile as dirty when initialized

### DIFF
--- a/include/xtensor-io/xchunk_store_manager.hpp
+++ b/include/xtensor-io/xchunk_store_manager.hpp
@@ -399,7 +399,7 @@ namespace xt
 
     template <class T, class IOH, layout_type L, class IP, class S>
     inline xchunked_array<xchunk_store_manager<xfile_array<T, IOH, L>, IP>>
-    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path,  const T& init_value, std::size_t pool_size, layout_type chunk_memory_layout)
+    chunked_file_array(std::initializer_list<S> shape, std::initializer_list<S> chunk_shape, const std::string& path, const T& init_value, std::size_t pool_size, layout_type chunk_memory_layout)
     {
         using sh_type = std::vector<std::size_t>;
         auto sh = xtl::forward_sequence<sh_type, std::initializer_list<S>>(shape);

--- a/include/xtensor-io/xfile_array.hpp
+++ b/include/xtensor-io/xfile_array.hpp
@@ -675,7 +675,6 @@ namespace xt
                     if (m_init)
                     {
                         std::fill(m_storage.begin(), m_storage.end(), m_init_value);
-                        m_dirty = true;
                     }
                 }
             }

--- a/include/xtensor-io/xio_aws_handler.hpp
+++ b/include/xtensor-io/xio_aws_handler.hpp
@@ -1,14 +1,14 @@
 #ifndef XTENSOR_IO_AWS_HANDLER_HPP
 #define XTENSOR_IO_AWS_HANDLER_HPP
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xexpression.hpp"
-#include "xfile_array.hpp"
-#include "xio_stream_wrapper.hpp"
+#include <xtensor/xarray.hpp>
+#include <xtensor/xexpression.hpp>
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
+#include "xfile_array.hpp"
+#include "xio_stream_wrapper.hpp"
 
 namespace xt
 {

--- a/include/xtensor-io/xio_disk_handler.hpp
+++ b/include/xtensor-io/xio_disk_handler.hpp
@@ -3,7 +3,8 @@
 
 #include <xtensor/xarray.hpp>
 #include <xtensor/xexpression.hpp>
-#include <xtensor-io/xio_stream_wrapper.hpp>
+#include "xio_stream_wrapper.hpp"
+#include "xfile_array.hpp"
 
 namespace xt
 {

--- a/include/xtensor-io/xio_gcs_handler.hpp
+++ b/include/xtensor-io/xio_gcs_handler.hpp
@@ -1,10 +1,11 @@
 #ifndef XTENSOR_IO_GCS_HANDLER_HPP
 #define XTENSOR_IO_GCS_HANDLER_HPP
 
+#include <xtensor/xarray.hpp>
+#include <xtensor/xexpression.hpp>
+#include <google/cloud/storage/client.h>
+#include "xfile_array.hpp"
 #include "xio_stream_wrapper.hpp"
-#include "xtensor/xarray.hpp"
-#include "xtensor/xexpression.hpp"
-#include "google/cloud/storage/client.h"
 
 namespace gcs = google::cloud::storage;
 

--- a/include/xtensor-io/xio_gdal_handler.hpp
+++ b/include/xtensor-io/xio_gdal_handler.hpp
@@ -3,8 +3,8 @@
 
 #include <xtensor/xarray.hpp>
 #include <xtensor/xexpression.hpp>
-#include <xtensor-io/xfile_array.hpp>
-#include <xtensor-io/xio_vsilfile_wrapper.hpp>
+#include "xfile_array.hpp"
+#include "xio_vsilfile_wrapper.hpp"
 
 #include <cpl_vsi.h>
 

--- a/test/test_xchunk_store_manager.cpp
+++ b/test/test_xchunk_store_manager.cpp
@@ -127,9 +127,7 @@ namespace xt
 
     TEST(xchunked_array, shape_initializer_list)
     {
-        std::vector<size_t> shape = {4, 4};
-        std::vector<size_t> chunk_shape = {2, 2};
-        auto a = chunked_file_array<double, xio_disk_handler<xio_binary_config>>({4, 4}, {2, 2}, "files3");
+        auto a = chunked_file_array<double, xio_disk_handler<xio_binary_config>>({4, 4}, {2, 2}, "files3", 5.5);
         for (auto v: a)
         {
             EXPECT_EQ(v, 5.5);


### PR DESCRIPTION
When a file array has a file mode of "init on fail", and we try to read it but it doesn't exist, we fill the in-memory array with a value if one was provided. We should not consider this array as dirty at this point, since this would inevitably lead to a flush. A flush should occur only if one or more elements of this array are changed explicitly (by assignment).
Reverts https://github.com/xtensor-stack/xtensor-io/pull/131/commits/de64647af1a181347d5f8fb301769019955bfcc5