### PR TITLE
Fix same MSVC compile error with 'alignas' inside for loop. related #146

### DIFF
--- a/include/xtensor-io/xnpz.hpp
+++ b/include/xtensor-io/xnpz.hpp
@@ -238,7 +238,8 @@ namespace xt
             throw std::runtime_error("load_npz: failed to open file " + filename);
         }
 
-        for (alignas(uint32_t) detail::zip_local_header entry;;)
+        alignas(uint32_t) detail::zip_local_header entry;
+        for (;;)
         {
             if (!stream.read(reinterpret_cast<char*>(&entry), sizeof(entry)))
             {


### PR DESCRIPTION
Same as #147.

Didn't catch the second instance in an overload. I searched for more instances but didn't find any more.