### PR TITLE
Fix highfive dump mode references

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -46,7 +46,7 @@ steps:
 
   - script: |
       source activate xtensor-io
-      ./test_xtensor_io_lib && ./test_xtensor_io_ho
+      ./test_xtensor_io_lib --gtest_filter="-xio_gdal_handler.read_vsigs" && ./test_xtensor_io_ho
     displayName: Test xtensor-io
     workingDirectory: $(Build.BinariesDirectory)/build/test
 

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -40,6 +40,12 @@ steps:
 
   - script: |
       source activate xtensor-io
+      python -c 'import struct, zlib; open("files/test.zl", "wb").write(zlib.compress(struct.pack("4d", 3.0, 2.0, 1.0, 0.0), level=1))'
+    displayName: Generate data for zlib test
+    workingDirectory: $(Build.BinariesDirectory)/build/test
+
+  - script: |
+      source activate xtensor-io
       ./test_xtensor_io_lib && ./test_xtensor_io_ho
     displayName: Test xtensor-io
     workingDirectory: $(Build.BinariesDirectory)/build/test

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -34,15 +34,13 @@ steps:
 
   - script: |
       source activate xtensor-io
-      make -j2 test_xtensor_io_lib
-      make -j2 test_xtensor_io_ho
+      make -j2 test_xtensor_io_lib test_xtensor_io_ho
     displayName: Build xtensor-io
     workingDirectory: $(Build.BinariesDirectory)/build
 
   - script: |
       source activate xtensor-io
-      ./test_xtensor_io_lib
-      ./test_xtensor_io_ho
+      ./test_xtensor_io_lib && ./test_xtensor_io_ho
     displayName: Test xtensor-io
     workingDirectory: $(Build.BinariesDirectory)/build/test
 

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -34,19 +34,13 @@ steps:
 
   - script: |
       source activate xtensor-io
-      make -j2 test_xtensor_io_lib test_xtensor_io_ho
-    displayName: Build xtensor-io
-    workingDirectory: $(Build.BinariesDirectory)/build
-
-  - script: |
-      source activate xtensor-io
       python -c 'import struct, zlib; open("files/test.zl", "wb").write(zlib.compress(struct.pack("4d", 3.0, 2.0, 1.0, 0.0), level=1))'
     displayName: Generate data for zlib test
     workingDirectory: $(Build.BinariesDirectory)/build/test
 
   - script: |
       source activate xtensor-io
-      ./test_xtensor_io_lib --gtest_filter="-xio_gdal_handler.read_vsigs" && ./test_xtensor_io_ho
-    displayName: Test xtensor-io
-    workingDirectory: $(Build.BinariesDirectory)/build/test
-
+      export GTEST_FILTER="-xio_gdal_handler.read_vsigs"
+      make -j2 xtest
+    displayName: Build and run xtensor-io tests
+    workingDirectory: $(Build.BinariesDirectory)/build

--- a/include/xtensor-io/xhighfive.hpp
+++ b/include/xtensor-io/xhighfive.hpp
@@ -102,11 +102,11 @@ namespace xt
             switch (mode)
             {
                 case xt::dump_mode::create:
-                  return HighFive::DumpMode::Create;
+                  return H5Easy::DumpMode::Create;
                 case xt::dump_mode::overwrite:
-                  return HighFive::DumpMode::Overwrite;
+                  return H5Easy::DumpMode::Overwrite;
                 default:
-                  return HighFive::DumpMode::Create;
+                  return H5Easy::DumpMode::Create;
             }
         }
     }


### PR DESCRIPTION
This PR fixes some references to the (non-existent) `HighFive::DumpMode` `enum`.

The build appears to be successful even though it's not.

Azure is taking the exit code of the last executed process as the indicator
of success or failure.

[Here](https://dev.azure.com/xtensor-stack/xtensor-stack/_build/results?buildId=2883&view=logs&j=6f6950ed-118e-5110-b7d1-309d986feacb&t=26dd8b2e-22bc-5158-33fc-bbdbd2b09255) you can see the failure:

```
/home/vsts/work/1/s/include/xtensor-io/xhighfive.hpp:105:36: error: 'HighFive::DumpMode' has not been declared
  105 |                   return HighFive::DumpMode::Create;
      |                                    ^~~~~~~~
```
from building the `test_xtensor_io_lib` target.

But, since building the `test_xtensor_io_ho` target succeeds Azure considers this a success.

The solution was to build both targets at the same time.

Additionally, I've chained the runs of the two test executables with an ampersand to ensure that
a similar problem doesn't occur when running tests.
