### PR TITLE
Show errors from OIIO

### DIFF
--- a/include/xtensor-io/ximage.hpp
+++ b/include/xtensor-io/ximage.hpp
@@ -52,7 +52,7 @@ namespace xt
         auto in(OIIO::ImageInput::open(filename));
         if (!in)
         {
-            throw std::runtime_error("load_image(): Error reading image '" + filename + "'.");
+            throw std::runtime_error("load_image(): Error reading image '" + filename + "': " + OIIO::geterror());
         }
 
         const OIIO::ImageSpec& spec = in->spec();
@@ -124,7 +124,7 @@ namespace xt
         auto out(OIIO::ImageOutput::create(filename)); 
         if (!out)
         {
-            throw std::runtime_error("dump_image(): Error opening file '" + filename + "' to write image.");
+            throw std::runtime_error("dump_image(): Error opening file '" + filename + "' to write image: " + OIIO::geterror());
         }
 
         OIIO::ImageSpec spec = options.spec;


### PR DESCRIPTION
This PR adds error messages from `OpenImageIO`, to the error message show by `xtensor-io`
when an OIIO operation fails.

This ended up being useful for tracking down a missing `giflib` dependency from
my installation.
