### PR TITLE
Allow partial building of test executables

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 find_package(Threads)
 
 set(XTENSOR_IO_TESTS main.cpp test_xio_binary.cpp)
+set(XTENSOR_IO_FILES)
 
 if (HAVE_GDAL)
     list(APPEND XTENSOR_IO_TESTS test_xgdal.cpp test_xio_gdal_handler.cpp)
@@ -81,22 +82,42 @@ endif()
 
 if (HAVE_ZLIB)
     list(APPEND XTENSOR_IO_TESTS test_xnpz.cpp test_xio_zlib.cpp test_xio_gzip.cpp)
+    list(
+        APPEND
+        XTENSOR_IO_FILES
+        compressed.npz
+        uncompressed.npz
+        compressed64.npz
+        uncompressed64.npz
+        test.gz
+    )
 endif()
 
 if (HAVE_HighFive)
     list(APPEND XTENSOR_IO_TESTS test_xhighfive.cpp)
+    list(APPEND XTENSOR_IO_FILES archive.h5)
 endif()
 
 if (HAVE_OIIO)
     list(APPEND XTENSOR_IO_TESTS test_ximage.cpp)
+    list(
+        APPEND
+        XTENSOR_IO_FILES
+        test.png
+        test.jpg
+        test.gif
+        big.jpg
+    )
 endif()
 
 if (HAVE_SndFile)
     list(APPEND XTENSOR_IO_TESTS test_xaudio.cpp)
+    list(APPEND XTENSOR_IO_FILES xtensor.wav)
 endif()
 
 if (HAVE_Blosc)
     list(APPEND XTENSOR_IO_TESTS test_xio_blosc.cpp)
+    list(APPEND XTENSOR_IO_FILES test.blosc)
 endif()
 
 if (HAVE_storage_client)
@@ -113,44 +134,7 @@ set(XTENSOR_IO_HO_TESTS
     test_xfile_array.cpp
 )
 
-set(XTENSOR_IO_FILES)
-
 # Add files for tests
-if (HAVE_HighFive)
-    list(APPEND XTENSOR_IO_FILES archive.h5)
-endif()
-
-if (HAVE_ZLIB)
-    list(
-        APPEND
-        XTENSOR_IO_FILES
-        compressed.npz
-        uncompressed.npz
-        compressed64.npz
-        uncompressed64.npz
-        test.gz
-    )
-endif()
-
-# if (HAVE_OIIO)
-list(
-    APPEND
-    XTENSOR_IO_FILES
-    test.png
-    test.jpg
-    test.gif
-    big.jpg
-)
-# endif()
-
-if (HAVE_Blosc)
-    list(APPEND XTENSOR_IO_FILES test.blosc)
-endif()
-
-if (HAVE_SndFile)
-    list(APPEND XTENSOR_IO_FILES xtensor.wav)
-endif()
-
 foreach(filename IN LISTS XTENSOR_IO_FILES)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/files/${filename}
         ${CMAKE_CURRENT_BINARY_DIR}/files/${filename} COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,21 +73,39 @@ endif()
 
 find_package(Threads)
 
-set(XTENSOR_IO_TESTS
-    main.cpp
-    test_xgdal.cpp
-    test_xnpz.cpp
-    test_xhighfive.cpp
-    test_ximage.cpp
-    test_xaudio.cpp
-    test_xio_blosc.cpp
-    test_xio_gzip.cpp
-    test_xio_zlib.cpp
-    test_xio_binary.cpp
-    test_xio_gcs_handler.cpp
-    test_xio_aws_handler.cpp
-    test_xio_gdal_handler.cpp
-)
+set(XTENSOR_IO_TESTS main.cpp test_xio_binary.cpp)
+
+if (HAVE_GDAL)
+    list(APPEND XTENSOR_IO_TESTS test_xgdal.cpp test_xio_gdal_handler.cpp)
+endif()
+
+if (HAVE_ZLIB)
+    list(APPEND XTENSOR_IO_TESTS test_xnpz.cpp test_xio_zlib.cpp test_xio_gzip.cpp)
+endif()
+
+if (HAVE_HighFive)
+    list(APPEND XTENSOR_IO_TESTS test_xhighfive.cpp)
+endif()
+
+if (HAVE_OIIO)
+    list(APPEND XTENSOR_IO_TESTS test_ximage.cpp)
+endif()
+
+if (HAVE_SndFile)
+    list(APPEND XTENSOR_IO_TESTS test_xaudio.cpp)
+endif()
+
+if (HAVE_Blosc)
+    list(APPEND XTENSOR_IO_TESTS test_xio_blosc.cpp)
+endif()
+
+if (HAVE_storage_client)
+    list(APPEND XTENSOR_IO_TESTS test_xio_gcs_handler.cpp)
+endif()
+
+if (HAVE_AWSSDK)
+    list(APPEND XTENSOR_IO_TESTS test_xio_aws_handler.cpp)
+endif()
 
 set(XTENSOR_IO_HO_TESTS
     main.cpp
@@ -95,21 +113,43 @@ set(XTENSOR_IO_HO_TESTS
     test_xfile_array.cpp
 )
 
+set(XTENSOR_IO_FILES)
+
 # Add files for tests
-set(XTENSOR_IO_FILES
-    archive.h5
-    compressed.npz
-    uncompressed.npz
-    compressed64.npz
-    uncompressed64.npz
+if (HAVE_HighFive)
+    list(APPEND XTENSOR_IO_FILES archive.h5)
+endif()
+
+if (HAVE_ZLIB)
+    list(
+        APPEND
+        XTENSOR_IO_FILES
+        compressed.npz
+        uncompressed.npz
+        compressed64.npz
+        uncompressed64.npz
+        test.gz
+    )
+endif()
+
+# if (HAVE_OIIO)
+list(
+    APPEND
+    XTENSOR_IO_FILES
     test.png
     test.jpg
     test.gif
-    test.blosc
-    test.gz
     big.jpg
-    xtensor.wav
 )
+# endif()
+
+if (HAVE_Blosc)
+    list(APPEND XTENSOR_IO_FILES test.blosc)
+endif()
+
+if (HAVE_SndFile)
+    list(APPEND XTENSOR_IO_FILES xtensor.wav)
+endif()
 
 foreach(filename IN LISTS XTENSOR_IO_FILES)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/files/${filename}


### PR DESCRIPTION
This PR ties the building of test executables to the optional dependencies that
were enabled during the `cmake` invocation.

In particular, this PR allows users to run tests for the optional dependencies
that were installed as opposed to requiring all optional dependencies for testing.

This is useful when packaging `xtensor-io`, in cases where not all optional dependencies
are available but running tests is still desired.
