### PR TITLE
Fix load_npz single-variable skip over extra fields

### DIFF
--- a/include/xtensor-io/xnpz.hpp
+++ b/include/xtensor-io/xnpz.hpp
@@ -303,8 +303,11 @@ namespace xt
             }
             else
             {
-                stream.seekg(static_cast<std::streamsize>(entry.compressed_size),
-                             std::ios_base::cur);
+                auto compressed_size = extract_zip64_compressed_size(stream, entry);
+                if (!stream.seekg(std::streamoff(compressed_size), std::ios_base::cur))
+                {
+                    throw std::runtime_error("load_npz: unable to skip the next variable.");
+                }
             }
         }
         throw std::runtime_error("Array "s + search_varname + " not found in file: "s + filename);


### PR DESCRIPTION
## Summary

This PR fixes `xt::load_npz(filename, search_varname)` when scanning NPZ files that contain a non-zero ZIP local header `extra_field_len`.

Previously, when the current array name did not match `search_varname`, the code skipped only `entry.compressed_size`. This left the stream positioned inside the current entry's extra field for NPZ files with `extra_field_len > 0`, causing subsequent local headers to be misread and later arrays to be reported as missing.

The fix reuses `extract_zip64_compressed_size(stream, entry)`, which already consumes the extra field and handles ZIP64 size metadata, then seeks over the compressed payload.

## Validation

I tested this change with a NumPy-generated `.npz` file whose local ZIP entries each have `extra_field_len = 20`.

Before this fix, reading an array that appears after the first entry failed:

```cpp
xt::load_npz<float>(filename, "body_quat_w");